### PR TITLE
lib:  fix disable bug

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -86,12 +86,6 @@ class Debugger extends events.EventEmitter {
     });
   }
 
-  disable(callback) {
-    this.client.request('Debugger.disable', function(error) {
-      callback(error);
-    });
-  }
-
   canSetScriptSource(callback) {
     this.client.request('Debugger.canSetScriptSource', function(error, result) {
       if (error) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -75,7 +75,7 @@ class Debugger extends events.EventEmitter {
   }
 
   disable(callback) {
-    this.client.request('Debugger.enable', function(error) {
+    this.client.request('Debugger.disable', function(error) {
       callback(error);
     });
   }


### PR DESCRIPTION
There is a duplicate of the `disable` method in `debugger`. They also request the method `Debugger.enable`

This removes the second `disable` method and change the first one to request `Debugger.disable`.
