### PR TITLE
fix socket message

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -265,7 +265,7 @@ class Client extends events.EventEmitter {
             if (message.error) {
               callback(message.error);
             } else {
-              callback(null, message.result);
+              callback(null, message);
             }
 
             delete this._callbacks[message.id];

--- a/test/client.js
+++ b/test/client.js
@@ -36,8 +36,8 @@ test('client requests', assert => {
 
           client.request('Console.disable', (error, result) => {
             assert.error(error);
-            assert.deepEqual(result.params, {});
-            assert.equal(result.method, 'Console.disable');
+            assert.deepEqual(result.result.params, {});
+            assert.equal(result.result.method, 'Console.disable');
 
             server.close();
             assert.pass('close');


### PR DESCRIPTION
Socket messages should do callback with only `message` and not `message.result` when message have callback with no errors.
