### PR TITLE
Add interface classes for DOM & CSS domains

### DIFF
--- a/lib/rdbg.js
+++ b/lib/rdbg.js
@@ -158,6 +158,157 @@ class Runtime extends events.EventEmitter {
 
 module.exports.Runtime = Runtime;
 
+class CSS extends events.EventEmitter {
+  constructor(client) {
+    super();
+
+    client.on('message', (method, params) => {
+      if (method === 'CSS.styleSheetAdded') {
+        this.emit('styleSheetAdded', params.header);
+      } else if (method === 'CSS.styleSheetRemoved') {
+        this.emit('styleSheetRemoved', params.styleSheetId);
+      } else if (method === 'CSS.styleSheetChanged') {
+        this.emit('styleSheetChanged', params.styleSheetId);
+      }
+    });
+
+    this._client = client;
+  }
+
+  get client() {
+    return this._client;
+  }
+
+  get enabled() {
+    return this._enabled;
+  }
+
+  enable(callback) {
+    let ensureDomEnabled = (next) => {
+      if (!this.client.dom.enabled) {
+        this.client.dom.enable((error) => {
+          if (!error) {
+            next();
+          }
+          else {
+            callback(error);
+          }
+        });
+      }
+      else {
+        next();
+      }
+    }
+
+    ensureDomEnabled(() => {
+      this.client.request('CSS.enable', error => {
+        if (!error) {
+          this._enabled = true;
+        }
+        return callback(error);
+      });
+    })
+  }
+
+  getStyleSheetText(styleSheetId, callback) {
+    this.client.request('CSS.getStyleSheetText', {
+      styleSheetId,
+    }, function(error, result) {
+      if (error) {
+        return callback(error);
+      }
+
+      callback(null, result.text);
+    });
+  }
+
+  setStyleSheetText(styleSheetId, text, callback) {
+    this.client.request('CSS.setStyleSheetText', {
+      styleSheetId,
+      text,
+    }, callback);
+  }
+}
+
+module.exports.CSS = CSS;
+
+class DOM extends events.EventEmitter {
+  constructor(client) {
+    super();
+
+    client.on('message', (method, params) => {
+    });
+
+    this._client = client;
+  }
+
+  get client() {
+    return this._client;
+  }
+
+  get enabled() {
+    return this._enabled;
+  }
+
+  enable(callback) {
+    this.client.request('DOM.enable', error => {
+      if (!error) {
+        this._enabled = true;
+      }
+      return callback(error);
+    });
+  }
+
+  getDocument(callback) {
+    this.client.request('DOM.getDocument', {},
+      function(error, result) {
+      if (error) {
+        return callback(error);
+      }
+
+      callback(null, result.root);
+    });
+  }
+
+  querySelector(nodeId, selector, callback) {
+    this.client.request('DOM.querySelector', {
+      nodeId, selector
+    }, function(error, result) {
+      if (error) {
+        return callback(error);
+      }
+
+      callback(null, result.nodeId);
+    });
+  }
+
+  querySelectorAll(nodeId, selector, callback) {
+    this.client.request('DOM.querySelectorAll', {
+      nodeId, selector
+    }, function(error, result) {
+      if (error) {
+        return callback(error);
+      }
+
+      callback(null, result.nodeIds);
+    });
+  }
+
+  setNodeValue(nodeId, string, callback) {
+    this.client.request('DOM.setNodeValue', {
+      nodeId, string
+    }, callback);
+  }
+
+  setAttributeValue(nodeId, name, value, callback) {
+    this.client.request('DOM.setAttributeValue', {
+      nodeId, name, value
+    }, callback);
+  }
+}
+
+module.exports.DOM = DOM;
+
 class Client extends events.EventEmitter {
   constructor() {
     super();
@@ -194,6 +345,22 @@ class Client extends events.EventEmitter {
     }
 
     return this._runtime;
+  }
+
+  get css() {
+    if (!this._css) {
+      this._css = new CSS(this);
+    }
+
+    return this._css;
+  }
+
+  get dom() {
+    if (!this._dom) {
+      this._dom = new DOM(this);
+    }
+
+    return this._dom;
   }
 
   request(method, parameters, id, callback) {


### PR DESCRIPTION
Hello @caspervonb ,

This patch very simply adds interfaces for working with DOM & CSS domains.

I have tested this against chrome -- it works. I'm not sure how to write a test suite for it though, and there aren't examples in the repo I could follow.

By the way: there's a lot of copying & pasting here right now. I'm wondering if I should instead generate these interface classes according to a spec, kinda like this:

``` js

let interfaceSpec = {
  DOM: {
    setAttributeValue: {
      input: ['nodeId', 'name', 'value'],
      output: []
    },
    querySelectorAll: {
      input: ['nodeId', 'selector'],
      output: ['nodeId']
    }
...
```

Thanks,
xkxx
